### PR TITLE
[~] Added continue-on-error: true in the chocolatine workflow

### DIFF
--- a/.github/workflows/chocolatine.yml
+++ b/.github/workflows/chocolatine.yml
@@ -84,6 +84,8 @@ jobs:
     container:
       image: epitechcontent/epitest-docker:latest
 
+    continue-on-error: true
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This makes unit tests not mandatory to merge, enabling us to work in parallel on features and unit tests for them