### PR TITLE
[+] Added variable replacement in user input

### DIFF
--- a/include/core/minishell.h
+++ b/include/core/minishell.h
@@ -200,6 +200,7 @@ void reset_initial_env(void);
 void clear_var(void);
 int is_var_readonly(IN var_node_t *var);
 int remove_var(char *key);
+char *var_search(IN char *key);
 
 /*
  * Termios helping functions

--- a/src/core/handlers/var_handler.c
+++ b/src/core/handlers/var_handler.c
@@ -88,3 +88,23 @@ int remove_var(IN char *key)
     }
     return OK_OUTPUT;
 }
+
+/**
+ * @brief A function to get a local variable by key
+ *
+ * @param key
+ * @return char*
+ */
+char *var_search(IN char *key)
+{
+    var_node_t *var = get_shell()->variables;
+
+    if (key == NULL)
+        return NULL;
+    while (var != NULL) {
+        if (my_strcmp(var->_key, key) == 0)
+            return var->_value;
+        var = var->_next;
+    }
+    return NULL;
+}

--- a/src/formatting/variables_handler.c
+++ b/src/formatting/variables_handler.c
@@ -102,7 +102,8 @@ string_t *extract_vars_in_array(char **array)
     return head;
 }
 
-static int replace_value(char ***argv, string_t *vars_replace, string_t *head)
+static int replace_value(OUT char ***argv, OUT string_t *vars_replace,
+    OUT string_t *head)
 {
     if (var_search(&vars_replace->string[1]) != NULL) {
         *argv = my_strreplace_array(*argv, vars_replace->string,

--- a/src/formatting/variables_handler.c
+++ b/src/formatting/variables_handler.c
@@ -102,6 +102,24 @@ string_t *extract_vars_in_array(char **array)
     return head;
 }
 
+static int replace_value(char ***argv, string_t *vars_replace, string_t *head)
+{
+    if (var_search(&vars_replace->string[1]) != NULL) {
+        *argv = my_strreplace_array(*argv, vars_replace->string,
+            var_search(&vars_replace->string[1]));
+        return OK_OUTPUT;
+    }
+    if (env_search(&vars_replace->string[1]) != NULL) {
+        *argv = my_strreplace_array(*argv, vars_replace->string,
+            env_search(&vars_replace->string[1]));
+        return OK_OUTPUT;
+    }
+    my_printf("%s: Undefined variable.\n", &vars_replace->string[1]);
+    get_shell()->last_exit_code = 1;
+    free_strings(head);
+    return ERROR_OUTPUT;
+}
+
 /*
  * Replace every variables use can find in the environments.
  * If we find a $PATH then replace array the $PATH by it's value.
@@ -116,14 +134,8 @@ int replace_env_variables(char ***argv)
     vars_replace = extract_vars_in_array(*argv);
     head = vars_replace;
     while (vars_replace != NULL) {
-        if (env_search(&vars_replace->string[1]) == NULL) {
-            my_printf("%s: Undefined variable.\n", &vars_replace->string[1]);
-            get_shell()->last_exit_code = 1;
-            free_strings(head);
+        if (replace_value(argv, vars_replace, head) == ERROR_OUTPUT)
             return ERROR_OUTPUT;
-        }
-        *argv = my_strreplace_array(*argv, vars_replace->string,
-            env_search(&vars_replace->string[1]));
         vars_replace = vars_replace->next;
     }
     free_strings(head);

--- a/src/formatting/variables_handler.c
+++ b/src/formatting/variables_handler.c
@@ -71,7 +71,7 @@ string_t *extract_vars_in_string(string_t *strings, char *input)
     int len;
     int tmp_result = 0;
 
-    if (strings == NULL || input == NULL)
+    if (input == NULL)
         return NULL;
     len = my_strlen(input);
     while (index < len) {


### PR DESCRIPTION
This branch fixes the issue #13 so environment variables are now correctly detected and replaced in the user input?
In addition, now that the 42sh can create local variables, these can now also be replaced.

In case a local and an environment variable have the same name, the local variable is chosen first.