### PR TITLE
Improved the local variable and path system

### DIFF
--- a/include/core/minishell.h
+++ b/include/core/minishell.h
@@ -235,9 +235,9 @@ void clear_var(void);
 int is_var_readonly(var_node_t *var);
 int remove_var(char *key);
 char **var_search(char *key);
-char *concat_strarray(IN char **array, IN char *separator);
-void insert_alphabetically(var_node_t *var, IN var_node_t *new_var,
-    IN char *key);
+char *concat_strarray(char **array, char *separator);
+void insert_alphabetically(var_node_t *var, var_node_t *new_var,
+    char *key);
 
 /*
  * Path variable

--- a/include/core/minishell.h
+++ b/include/core/minishell.h
@@ -56,7 +56,7 @@ typedef struct env_node_s {
  */
 typedef struct var_node_s {
     char *_key;
-    char *_value;
+    char **_value;
     int _read_only;
     struct var_node_s *_next;
 } var_node_t;
@@ -230,10 +230,12 @@ void reset_initial_env(void);
 /*
  * Local variables
  */
+void free_var_value(var_node_t *var);
 void clear_var(void);
 int is_var_readonly(var_node_t *var);
 int remove_var(char *key);
-char *var_search(IN char *key);
+char **var_search(char *key);
+char *concat_strarray(char **array);
 
 /*
  * Termios helping functions
@@ -321,7 +323,7 @@ bool is_alpha_num(char *string);
 int len_to_first_char(char *str);
 
 int char_in_str(char *str, char c);
-int find_char_index_in_tab(IN char **tab, IN char c);
+int find_char_index_in_tab(char **tab, char c);
 
 /*
  * Files functions

--- a/include/core/minishell.h
+++ b/include/core/minishell.h
@@ -235,7 +235,16 @@ void clear_var(void);
 int is_var_readonly(var_node_t *var);
 int remove_var(char *key);
 char **var_search(char *key);
-char *concat_strarray(char **array);
+char *concat_strarray(IN char **array, IN char *separator);
+void insert_alphabetically(var_node_t *var, IN var_node_t *new_var,
+    IN char *key);
+
+/*
+ * Path variable
+*/
+void add_path_variable(shell_variables_t *vars);
+void update_env_path(char *key, char **value);
+void update_var_path(void);
 
 /*
  * Termios helping functions

--- a/src/builtins/set.c
+++ b/src/builtins/set.c
@@ -167,7 +167,7 @@ int is_var_readonly(IN var_node_t *var)
  * @param new_var
  * @param key
  */
-static void insert_alphabetically(var_node_t *var, IN var_node_t *new_var,
+void insert_alphabetically(var_node_t *var, IN var_node_t *new_var,
     IN char *key)
 {
     var_node_t *current = var;
@@ -232,6 +232,7 @@ static int modify_or_create_var(OUT char *key, IN char **argv,
         free_var_value(var);
         var->_value = get_new_var_value(key, argv, is_readonly);
         var->_read_only = is_readonly;
+        update_env_path(key, var->_value);
         return OK_OUTPUT;
     }
     return add_variable(argv, is_readonly);

--- a/src/builtins/set.c
+++ b/src/builtins/set.c
@@ -14,12 +14,10 @@
  * @param str
  * @return int
  */
-static int is_value_wordlist(IN char *str)
+static int is_value_wordlist(IN char **str)
 {
-    if (str == NULL)
-        return 0;
-    for (int i = 0; str[i] != '\0'; i++) {
-        if (str[i] == ' ')
+    for (int i = 0; str[i] != NULL; i++) {
+        if (i > 0)
             return 1;
     }
     return 0;
@@ -42,10 +40,74 @@ static int print_variables(IN int is_readonly)
         }
         is_wordlist = is_value_wordlist(var->_value);
         my_printf("%s\t", var->_key);
-        if (var->_value != NULL)
-            my_printf("%.*s%s", is_wordlist, "(", var->_value);
-        my_printf("%.*s\n", is_wordlist, ")");
+        for (int i = 0; var->_value[i] != NULL; i++) {
+            my_printf("%.*s%.*s%s%.*s", (i > 0), " ",
+            (is_wordlist && i == 0), "(",
+            var->_value[i], (is_wordlist && var->_value[i + 1] == NULL), ")");
+        }
+        my_printf("\n");
         var = var->_next;
+    }
+    return OK_OUTPUT;
+}
+
+/**
+ * @brief A function to get the strarray value of a local variable
+ *
+ * @param new_value
+ * @param argv
+ * @param key_len
+ * @param is_readonly
+ * @return char**
+ */
+static char **get_strarray(OUT char **new_value, IN char **argv,
+    IN int key_len, IN int is_readonly)
+{
+    int value_index = 0;
+
+    new_value = realloc(new_value, sizeof(char *) * 2);
+    new_value[value_index] = my_strdup(&argv[is_readonly + 1][key_len + 2]);
+    new_value[value_index + 1] = NULL;
+    if (new_value[value_index][my_strlen(new_value[value_index]) - 1] == ')')
+        new_value[value_index][my_strlen(new_value[value_index]) - 1] = '\0';
+    value_index++;
+    for (int i = is_readonly + 2; argv[i] != NULL; i++) {
+        new_value = realloc(new_value, sizeof(char *) * (value_index + 2));
+        new_value[value_index] = my_strdup(argv[i]);
+        new_value[value_index + 1] = NULL;
+        value_index++;
+    }
+    if (new_value[value_index - 1]
+        [my_strlen(new_value[value_index - 1]) - 1] == ')')
+        new_value[value_index - 1]
+            [my_strlen(new_value[value_index - 1]) - 1] = '\0';
+    return new_value;
+}
+
+/**
+ * @brief A function to handle the error of the wordlist of a local variable
+ *
+ * @param argv
+ * @param is_readonly
+ * @param key_len
+ * @return int
+ */
+static int handle_wordlist_error(IN char **argv, IN int is_readonly,
+    IN int key_len)
+{
+    int argc = array_count_string(argv);
+
+    if (argv[is_readonly + 1][key_len] == '\0')
+        return OK_OUTPUT;
+    if (argv[is_readonly + 1][key_len + 1] == '(' &&
+        argv[argc - 1][my_strlen(argv[argc - 1]) - 1] != ')') {
+            print_err("Too many ('s.\n");
+        return ERROR_OUTPUT;
+    }
+    if (argv[argc - 1][my_strlen(argv[argc - 1]) - 1] == ')' &&
+        argv[is_readonly + 1][key_len + 1] != '(') {
+            print_err("Too many )'s.\n");
+        return ERROR_OUTPUT;
     }
     return OK_OUTPUT;
 }
@@ -56,28 +118,23 @@ static int print_variables(IN int is_readonly)
  *
  * @param key
  * @param argv
- * @return char*
+ * @return char**
  */
-static char *get_new_var_value(IN char *key, IN char **argv,
+static char **get_new_var_value(IN char *key, IN char **argv,
     IN int is_readonly)
 {
     int key_len = my_strlen(key);
-    char *new_value = NULL;
+    char **new_value = calloc(1, sizeof(char *));
 
     if (key_len == my_strlen(argv[is_readonly + 1]))
         return new_value;
-    if (argv[is_readonly + 1][key_len + 1] == '(') {
-        new_value = my_strdup(&argv[is_readonly + 1][key_len + 2]);
-        for (int i = is_readonly + 2; argv[i] != NULL; i++) {
-            new_value = realloc(new_value,
-                my_strlen(new_value) + my_strlen(argv[i]) + 2);
-            new_value = my_strcat(new_value, " ");
-            new_value = my_strcat(new_value, argv[i]);
-        }
-        if (new_value[my_strlen(new_value) - 1] == ')')
-            new_value[my_strlen(new_value) - 1] = '\0';
-    } else
-        new_value = my_strdup(&argv[is_readonly + 1][key_len + 1]);
+    if (argv[is_readonly + 1][key_len + 1] == '(')
+        new_value = get_strarray(new_value, argv, key_len, is_readonly);
+    else {
+        new_value = realloc(new_value, sizeof(char *) * 2);
+        new_value[0] = my_strdup(&argv[is_readonly + 1][key_len + 1]);
+        new_value[1] = NULL;
+    }
     return new_value;
 }
 
@@ -127,9 +184,9 @@ static int add_variable(IN char **argv, IN int is_readonly)
  * @param argv
  * @return int
  */
-static int modify_or_create_var(IN char **argv, IN int is_readonly)
+static int modify_or_create_var(OUT char *key, IN char **argv,
+    IN int is_readonly)
 {
-    char *key = my_strtok(argv[is_readonly + 1], '=');
     var_node_t *var = get_shell()->variables;
 
     while (var != NULL) {
@@ -137,17 +194,13 @@ static int modify_or_create_var(IN char **argv, IN int is_readonly)
             var = var->_next;
             continue;
         }
-        if (is_var_readonly(var) == ERROR_OUTPUT) {
-            free(key);
+        if (is_var_readonly(var) == ERROR_OUTPUT)
             return ERROR_OUTPUT;
-        }
-        free_null_check(var->_value);
+        free_var_value(var);
         var->_value = get_new_var_value(key, argv, is_readonly);
         var->_read_only = is_readonly;
-        free(key);
         return OK_OUTPUT;
     }
-    free(key);
     return add_variable(argv, is_readonly);
 }
 
@@ -163,6 +216,7 @@ exitcode_t set_command(IN char **argv)
     ssize_t argv_count = array_count_string(argv);
     int is_readonly = 0;
     int value_index = 1;
+    char *key;
 
     if (argv[value_index] != NULL && my_strcmp(argv[value_index], "-r") == 0) {
         is_readonly = 1;
@@ -171,7 +225,12 @@ exitcode_t set_command(IN char **argv)
     }
     if (argv_count == 1)
         return print_variables(is_readonly);
-    if (modify_or_create_var(argv, is_readonly) == ERROR_OUTPUT)
+    key = my_strtok(argv[is_readonly + 1], '=');
+    if (handle_wordlist_error(argv, is_readonly, my_strlen(key)) ||
+        modify_or_create_var(key, argv, is_readonly)) {
+        free(key);
         return ERROR_OUTPUT;
+    }
+    free(key);
     return OK_OUTPUT;
 }

--- a/src/builtins/set.c
+++ b/src/builtins/set.c
@@ -167,7 +167,7 @@ int is_var_readonly(IN var_node_t *var)
  * @param new_var
  * @param key
  */
-void insert_alphabetically(var_node_t *var, IN var_node_t *new_var,
+void insert_alphabetically(IN var_node_t *var, IN var_node_t *new_var,
     IN char *key)
 {
     var_node_t *current = var;

--- a/src/builtins/set.c
+++ b/src/builtins/set.c
@@ -160,6 +160,33 @@ int is_var_readonly(IN var_node_t *var)
 }
 
 /**
+ * @brief A function to insert a new lcoal variable
+ * so the linked list is sorted alphabetically
+ *
+ * @param var
+ * @param new_var
+ * @param key
+ */
+static void insert_alphabetically(var_node_t *var, IN var_node_t *new_var,
+    IN char *key)
+{
+    var_node_t *current = var;
+    var_node_t *previous = NULL;
+
+    while (current != NULL && my_strcmp(current->_key, key) < 0) {
+        previous = current;
+        current = current->_next;
+    }
+    if (previous == NULL) {
+        new_var->_next = get_shell()->variables;
+        get_shell()->variables = new_var;
+    } else {
+        new_var->_next = current;
+        previous->_next = new_var;
+    }
+}
+
+/**
  * @brief A function to add a local variable if it doesn't exist
  *
  * @param argv
@@ -180,8 +207,7 @@ static int add_variable(IN char **argv, IN int is_readonly)
     new_var->_key = key;
     new_var->_value = get_new_var_value(key, argv, is_readonly);
     new_var->_read_only = is_readonly;
-    new_var->_next = var;
-    get_shell()->variables = new_var;
+    insert_alphabetically(var, new_var, key);
     return OK_OUTPUT;
 }
 

--- a/src/builtins/setenv.c
+++ b/src/builtins/setenv.c
@@ -14,6 +14,7 @@ static exitcode_t modify_shell_vars(char *key, char *value)
     if (!my_strcmp(key, "PATH")) {
         free_null_check(get_shell()->vars->path_var);
         get_shell()->vars->path_var = my_strdup(value);
+        update_var_path();
     }
     return OK_OUTPUT;
 }
@@ -35,6 +36,22 @@ static exitcode_t handle_error(IN char **array)
     return OK_OUTPUT;
 }
 
+/**
+ * @brief A function to handle the error of the name of the variable
+ *
+ * @param argv
+ * @return exitcode_t
+ */
+static exitcode_t handle_incorrect_name(char **argv)
+{
+    if (!is_letter(argv[1][0]) && argv[1][0] != '_')
+        return print_err("setenv: Variable name must begin with a letter.\n");
+    if (!is_alpha_num(argv[1]))
+        return print_err("setenv: Variable name must contain"
+            " alphanumeric characters.\n");
+    return OK_OUTPUT;
+}
+
 /*
  * SETENV COMMAND - BUILT-IN
  * This command will add or modify an environment variable using their key
@@ -49,11 +66,8 @@ exitcode_t setenv_command(char **argv)
         return ERROR_OUTPUT;
     if (argv[1] == NULL)
         return env_command(argv);
-    if (!is_letter(argv[1][0]) && argv[1][0] != '_')
-        return print_err("setenv: Variable name must begin with a letter.\n");
-    if (!is_alpha_num(argv[1]))
-        return print_err("setenv: Variable name must contain"
-            " alphanumeric characters.\n");
+    if (handle_incorrect_name(argv) == ERROR_OUTPUT)
+        return ERROR_OUTPUT;
     key = my_strdup(argv[1]);
     if (argv[2] == NULL)
         value = my_strdup("");
@@ -61,5 +75,6 @@ exitcode_t setenv_command(char **argv)
         value = my_strdup(argv[2]);
     modify_shell_vars(key, value);
     add_env(key, value);
+    free(key);
     return OK_OUTPUT;
 }

--- a/src/builtins/setenv.c
+++ b/src/builtins/setenv.c
@@ -42,7 +42,7 @@ static exitcode_t handle_error(IN char **array)
  * @param argv
  * @return exitcode_t
  */
-static exitcode_t handle_incorrect_name(char **argv)
+static exitcode_t handle_incorrect_name(IN char **argv)
 {
     if (!is_letter(argv[1][0]) && argv[1][0] != '_')
         return print_err("setenv: Variable name must begin with a letter.\n");

--- a/src/core/handlers/path_handler.c
+++ b/src/core/handlers/path_handler.c
@@ -1,0 +1,79 @@
+/*
+** EPITECH PROJECT, 2025
+** path_handler
+** File description:
+** Functions to manipulate the path in the 42sh
+*/
+
+#include "core/minishell.h"
+
+static void copy_path_to_var(char *path_env, var_node_t *new_var)
+{
+    char *path_elem;
+    int path_count = 0;
+
+    if (path_env == NULL)
+        return;
+    new_var->_value = calloc(1, sizeof(char *));
+    path_elem = my_strtok(path_env, ':');
+    while (path_elem != NULL) {
+        if (path_elem == NULL)
+            break;
+        new_var->_value = realloc(new_var->_value,
+            sizeof(char *) * (path_count + 2));
+        new_var->_value[path_count] = my_strdup(path_elem);
+        new_var->_value[path_count + 1] = NULL;
+        path_count++;
+        free_null_check(path_elem);
+        path_elem = my_strtok(NULL, ':');
+    }
+    free_null_check(path_elem);
+}
+
+void add_path_variable(shell_variables_t *vars)
+{
+    var_node_t *new_var = calloc(1, sizeof(var_node_t));
+    char *path_env = vars->path_var;
+
+    if (new_var == NULL)
+        return;
+    new_var->_key = my_strdup("path");
+    copy_path_to_var(path_env, new_var);
+    insert_alphabetically(get_shell()->variables, new_var, "path");
+}
+
+void update_env_path(char *key, char **value)
+{
+    if (my_strcmp(key, "path") != 0)
+        return;
+    free_null_check(get_shell()->vars->path_var);
+    get_shell()->vars->path_var = concat_strarray(value, ":");
+    add_env("PATH", my_strdup(get_shell()->vars->path_var));
+    return;
+}
+
+static void separate_var_path(char *var_path)
+{
+    for (int i = 0; var_path[i] != '\0'; i++) {
+        if (var_path[i] == ':') {
+            var_path[i] = ' ';
+            continue;
+        }
+    }
+}
+
+void update_var_path(void)
+{
+    char *var_path = get_shell()->vars->path_var;
+    char **argv = calloc(3, sizeof(char *));
+
+    argv[0] = my_strdup("set");
+    argv[1] = calloc(my_strlen(var_path) + 5, sizeof(char *));
+    my_strcpy(argv[1], "path=");
+    separate_var_path(var_path);
+    my_strcat(argv[1], var_path);
+    set_command(argv);
+    free_null_check(argv[0]);
+    free_null_check(argv[1]);
+    free_null_check(argv);
+}

--- a/src/core/handlers/path_handler.c
+++ b/src/core/handlers/path_handler.c
@@ -7,7 +7,7 @@
 
 #include "core/minishell.h"
 
-static void copy_path_to_var(char *path_env, var_node_t *new_var)
+static void copy_path_to_var(IN char *path_env, OUT var_node_t *new_var)
 {
     char *path_elem;
     int path_count = 0;
@@ -30,7 +30,7 @@ static void copy_path_to_var(char *path_env, var_node_t *new_var)
     free_null_check(path_elem);
 }
 
-void add_path_variable(shell_variables_t *vars)
+void add_path_variable(IN shell_variables_t *vars)
 {
     var_node_t *new_var = calloc(1, sizeof(var_node_t));
     char *path_env = vars->path_var;
@@ -42,7 +42,7 @@ void add_path_variable(shell_variables_t *vars)
     insert_alphabetically(get_shell()->variables, new_var, "path");
 }
 
-void update_env_path(char *key, char **value)
+void update_env_path(IN char *key, IN char **value)
 {
     if (my_strcmp(key, "path") != 0)
         return;
@@ -52,7 +52,7 @@ void update_env_path(char *key, char **value)
     return;
 }
 
-static void separate_var_path(char *var_path)
+static void separate_var_path(OUT char *var_path)
 {
     for (int i = 0; var_path[i] != '\0'; i++) {
         if (var_path[i] == ':') {

--- a/src/core/handlers/var_handler.c
+++ b/src/core/handlers/var_handler.c
@@ -138,7 +138,7 @@ static int get_strarray_len(IN char **strarray)
  * @param array
  * @return char*
  */
-char *concat_strarray(IN char **array)
+char *concat_strarray(IN char **array, IN char *separator)
 {
     char *str = NULL;
     int len = 0;
@@ -155,7 +155,7 @@ char *concat_strarray(IN char **array)
             continue;
         my_strcat(str, array[i]);
         if (array[i + 1] != NULL && my_strlen(array[i + 1]) != 0)
-            my_strcat(str, " ");
+            my_strcat(str, separator);
     }
     return str;
 }

--- a/src/core/handlers/var_handler.c
+++ b/src/core/handlers/var_handler.c
@@ -7,15 +7,27 @@
 
 #include "core/minishell.h"
 
+/**
+ * @brief A function to free the value of a lcoal variable
+ *
+ * @param var
+ */
+void free_var_value(OUT var_node_t *var)
+{
+    for (int i = 0; var->_value[i] != NULL; i++)
+        free_null_check(var->_value[i]);
+    free_null_check(var->_value);
+}
+
 /*
  * Free a node of the variables.
  */
-static void free_var(IN var_node_t *var)
+static void free_var(OUT var_node_t *var)
 {
     if (var == NULL)
         return;
     free_null_check(var->_key);
-    free_null_check(var->_value);
+    free_var_value(var);
     free_null_check(var);
 }
 
@@ -95,7 +107,7 @@ int remove_var(IN char *key)
  * @param key
  * @return char*
  */
-char *var_search(IN char *key)
+char **var_search(IN char *key)
 {
     var_node_t *var = get_shell()->variables;
 
@@ -107,4 +119,31 @@ char *var_search(IN char *key)
         var = var->_next;
     }
     return NULL;
+}
+
+/**
+ * @brief A function to concat the value of a local variable
+ *
+ * @param array
+ * @return char*
+ */
+char *concat_strarray(IN char **array)
+{
+    char *str = NULL;
+    int len = 0;
+
+    if (array == NULL)
+        return NULL;
+    for (int i = 0; array[i] != NULL; i++)
+        len += my_strlen(array[i]) + 1;
+    str = malloc(sizeof(char) * (len + 1));
+    if (str == NULL)
+        return NULL;
+    str[0] = '\0';
+    for (int i = 0; array[i] != NULL; i++) {
+        my_strcat(str, array[i]);
+        if (array[i + 1] != NULL)
+            my_strcat(str, " ");
+    }
+    return str;
 }

--- a/src/core/handlers/var_handler.c
+++ b/src/core/handlers/var_handler.c
@@ -121,6 +121,17 @@ char **var_search(IN char *key)
     return NULL;
 }
 
+static int get_strarray_len(IN char **strarray)
+{
+    int len = 0;
+
+    if (strarray == NULL)
+        return 0;
+    for (int i = 0; strarray[i] != NULL; i++)
+        len += my_strlen(strarray[i]) + 1;
+    return len;
+}
+
 /**
  * @brief A function to concat the value of a local variable
  *
@@ -134,15 +145,16 @@ char *concat_strarray(IN char **array)
 
     if (array == NULL)
         return NULL;
-    for (int i = 0; array[i] != NULL; i++)
-        len += my_strlen(array[i]) + 1;
+    len = get_strarray_len(array);
     str = malloc(sizeof(char) * (len + 1));
     if (str == NULL)
         return NULL;
     str[0] = '\0';
     for (int i = 0; array[i] != NULL; i++) {
+        if (my_strlen(array[i]) == 0)
+            continue;
         my_strcat(str, array[i]);
-        if (array[i + 1] != NULL)
+        if (array[i + 1] != NULL && my_strlen(array[i + 1]) != 0)
             my_strcat(str, " ");
     }
     return str;

--- a/src/core/shell_variables.c
+++ b/src/core/shell_variables.c
@@ -25,9 +25,10 @@ shell_variables_t *create_shell_vars(void)
     vars->pwd_var = getcwd(NULL, 0);
     vars->oldpwd_var = NULL;
     if (env_search("PATH") == NULL)
-        vars->path_var = my_strdup("/bin");
+        vars->path_var = my_strdup("/usr/bin:/bin");
     else
         vars->path_var = my_strdup(env_search("PATH"));
+    add_path_variable(vars);
     vars->history_lines_count = count_number_lines_history();
     vars->github_repository = get_github_repository_name();
     return vars;

--- a/src/formatting/variables_handler.c
+++ b/src/formatting/variables_handler.c
@@ -105,9 +105,13 @@ string_t *extract_vars_in_array(char **array)
 static int replace_value(OUT char ***argv, OUT string_t *vars_replace,
     OUT string_t *head)
 {
+    char *concatenated = NULL;
+
     if (var_search(&vars_replace->string[1]) != NULL) {
+        concatenated = concat_strarray(var_search(&vars_replace->string[1]));
         *argv = my_strreplace_array(*argv, vars_replace->string,
-            var_search(&vars_replace->string[1]));
+            concatenated);
+        free_null_check(concatenated);
         return OK_OUTPUT;
     }
     if (env_search(&vars_replace->string[1]) != NULL) {

--- a/src/formatting/variables_handler.c
+++ b/src/formatting/variables_handler.c
@@ -108,7 +108,8 @@ static int replace_value(OUT char ***argv, OUT string_t *vars_replace,
     char *concatenated = NULL;
 
     if (var_search(&vars_replace->string[1]) != NULL) {
-        concatenated = concat_strarray(var_search(&vars_replace->string[1]));
+        concatenated = concat_strarray(var_search(&vars_replace->string[1]),
+            " ");
         *argv = my_strreplace_array(*argv, vars_replace->string,
             concatenated);
         free_null_check(concatenated);

--- a/src/utilities/environment/binaries_path.c
+++ b/src/utilities/environment/binaries_path.c
@@ -26,7 +26,7 @@ static bool is_binary_existing(char full_path[4096], char *dir, char *command)
 /*
  * Try to find the path of the binary in all PATH env variable.
  */
-static char *find_binary_in_paths(char *path_var, char *command)
+static char *find_binary_in_paths(IN char *path_var, IN char *command)
 {
     char *dir = my_strtok(path_var, ':');
     char *result = NULL;
@@ -52,7 +52,7 @@ static char *find_binary_in_paths(char *path_var, char *command)
  * Starting with : '/' or '.'
  * If the PATH env variable exist then start finding it in the env PATH.
  */
-char *get_binary_path(char *command)
+char *get_binary_path(IN char *command)
 {
     char *path = concat_strarray(var_search("path"), ":");
 

--- a/src/utilities/environment/binaries_path.c
+++ b/src/utilities/environment/binaries_path.c
@@ -28,8 +28,7 @@ static bool is_binary_existing(char full_path[4096], char *dir, char *command)
  */
 static char *find_binary_in_paths(char *path_var, char *command)
 {
-    char *path_copy = my_strdup(path_var);
-    char *dir = my_strtok(path_copy, ':');
+    char *dir = my_strtok(path_var, ':');
     char *result = NULL;
     char full_path[4096];
 
@@ -44,7 +43,7 @@ static char *find_binary_in_paths(char *path_var, char *command)
         if (dir == NULL)
             break;
     }
-    free(path_copy);
+    free(path_var);
     return result;
 }
 
@@ -55,7 +54,7 @@ static char *find_binary_in_paths(char *path_var, char *command)
  */
 char *get_binary_path(char *command)
 {
-    char *path = get_shell()->vars->path_var;
+    char *path = concat_strarray(var_search("path"), ":");
 
     if (access(command, X_OK) == 0)
         return my_strdup(command);


### PR DESCRIPTION
This pull request fixes some issue with the set builtin, wordlist are now stored as char ** for easier manipulation.
Known issues: when using too much parenthesis with the set builtin, tcsh does some weird thing, this could need some further digging if we miss some automated tests.

The path is now primarly stored in the lcoal variables instead of the environment variable.
At the shell's start, if there is a PATH in the environment variable, it is copied in the local variable as a primary access, when the path is changed in either the local or environment variable, the change is made in the other party
If there is no PATH at the shell's start, `/usr/bin:/bin` is hardcoded to match TCSH's behavior.

These changes should (*hopefully*) complete the 'var interpreter' & 'path handling' sections of the automated tests.